### PR TITLE
pointer-events css property is removed correctly

### DIFF
--- a/src/angular-drag-drop.js
+++ b/src/angular-drag-drop.js
@@ -303,7 +303,7 @@ Angular.module("filearts.dragDrop", [
 
     var eventData = dropContainer.updateDragTarget(e, true);
     
-    dropContainer.el.children().css({'pointer-events': null});
+    dropContainer.el.children().css({'pointer-events': ''});
     dropContainer.el.removeClass("drop-container-active");
 
     if (dropContainer.callbacks.onDragLeave) {
@@ -318,7 +318,7 @@ Angular.module("filearts.dragDrop", [
 
     dropContainer.updateDragTarget(e, true);    
 
-    dropContainer.el.children().css({'pointer-events': null});
+    dropContainer.el.children().css({'pointer-events': ''});
     dropContainer.el.removeClass("drop-container-active");
   };
   


### PR DESCRIPTION
As per http://api.jquery.com/css/#css2 a property will be cleared when setting its value to emptry string.
