### PR TITLE
feat: use webpack umd librarytarget to build dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "./src/angular-drag-drop.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build:dev": "umd -c angular-drag-drop ./src/angular-drag-drop.js ./dist/angular-drag-drop.js",
-    "build:prod": "umd -c angular-drag-drop ./src/angular-drag-drop.js | uglifyjs -o ./dist/angular-drag-drop.min.js",
-    "build": "npm run build:dev && npm run build:prod",
+    "build": "webpack --config webpack.config.js",
     "build-example": "cd example && webpack",
     "start": "cd example && webpack-dev-server"
   },
@@ -34,8 +32,6 @@
     "exports-loader": "^0.6.2",
     "less-loader": "^2.2.1",
     "style-loader": "^0.13.0",
-    "uglify-js": "^2.7.0",
-    "umd": "^3.0.1",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,30 +1,38 @@
-module.exports = {
+var webpack = require('webpack');
+
+var devConfig = {
     cache: true,
     entry: {
-        'angular-drag-drop': __dirname + "/src/angular-drag-drop.js",
+        'angular-drag-drop': __dirname + "/src/angular-drag-drop.js"
     },
     output: {
         libraryTarget: "umd",
         library: "AngularDragDrop",
         path: "./dist",
-        pathInfo: false,
-        // publicPath: "/static/",
-        filename: "angular-drag-drop.js",
+        filename: "angular-drag-drop.js"
     },
     externals: {
-        'angular': 'angular',
-    },
-    module: {
-        loaders: [{
-            test: /\.less$/,
-            loaders: ['style-loader', 'css-loader', 'autoprefixer-loader', 'less-loader'],
-        }],
-        // noParse: [
-        //   require.resolve('angular'),
-        // ]
-    },
-    resolve: {
-        modulesDirectories: ["node_modules", "src"],
-        root: __dirname,
-    },
+        'angular': 'angular'
+    }
 };
+
+var prodConfig = {
+    cache: true,
+    entry: {
+        'angular-drag-drop': __dirname + "/src/angular-drag-drop.js"
+    },
+    output: {
+        libraryTarget: "umd",
+        library: "AngularDragDrop",
+        path: "./dist",
+        filename: "angular-drag-drop.min.js"
+    },
+    externals: {
+        'angular': 'angular'
+    },
+    plugins: [
+        new webpack.optimize.UglifyJsPlugin()
+    ]
+};
+
+module.exports = [devConfig, prodConfig];


### PR DESCRIPTION
fix: #20 

Change build to use `webpack` to produce the dist files using the `libraryTarget` `umd`.
